### PR TITLE
Extension runs automatically whenever file, folder is changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,21 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": ["onStartupFinished" ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
         "command": "codesnapshot.helloWorld",
         "title": "Hello World"
+      },
+      {
+        "command": "fileChangeMonitor.showChangePrompt",
+        "title": "File Changed!"
+      },
+      {
+        "command": "fileChangeMonitor.showWorkspaceLoadedPrompt",
+        "title": "Workspace Loaded!"
       }
     ]
   },


### PR DESCRIPTION
You get messages when anything happens in the bottom right corner of the vscode. Give me your feedback, and I will convert these messages into choice that the user can choose - whether to run the extension or not.